### PR TITLE
Fix input size when pasting

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -406,7 +406,9 @@
        */
       self.$input.on("paste", $.proxy(function(event) {
         event.preventDefault();
-        self.$input.val((event.originalEvent || event).clipboardData.getData('text/plain').replaceAll("\n", self.options.pasteDelimeterForNewLine));
+        var clipboadContent = (event.originalEvent || event).clipboardData.getData('text/plain');
+        self.$input.val(clipboadContent.replaceAll("\n", self.options.pasteDelimeterForNewLine));
+        self.$input.attr('size', clipboadContent.length);
       },self));
 
       self.$container.on('keydown', 'input', $.proxy(function(event) {


### PR DESCRIPTION
PR #25 solved the delimiter problem, but seems to have caused a bug. Currently, when we paste text into the input field, the input field will not automatically grow to the size of the pasted text. The present PR fixed this bug by adjusting the input field's size.