### PR TITLE
Use prop() and val() instead of attr()/removeAttr()

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -150,7 +150,7 @@
       if (self.isSelect && !optionExists) {
         var $option = $('<option selected>' + htmlEncode(itemText) + '</option>');
         $option.data('item', item);
-        $option.attr('value', itemValue);
+        $option.val(itemValue);
         self.$element.append($option);
       }
 
@@ -248,7 +248,7 @@
 
           if (self.isSelect) {
             var option = $('option', self.$element).filter(function() { return $(this).data('item') === item; });
-            option.attr('value', itemValue);
+            option.val(itemValue);
           }
       });
     },
@@ -373,8 +373,8 @@
       }
 
       self.$container.on('click', $.proxy(function(event) {
-        if (! self.$element.attr('disabled')) {
-          self.$input.removeAttr('disabled');
+        if (! self.$element.prop('disabled')) {
+          self.$input.prop('disabled', false);
         }
         self.$input.focus();
       }, self));
@@ -404,8 +404,8 @@
         var $input = $(event.target),
             $inputWrapper = self.findInputWrapper();
 
-        if (self.$element.attr('disabled')) {
-          self.$input.attr('disabled', 'disabled');
+        if (self.$element.prop('disabled')) {
+          self.$input.prop('disabled', true);
           return;
         }
 
@@ -462,8 +462,8 @@
       self.$container.on('keypress', 'input', $.proxy(function(event) {
          var $input = $(event.target);
 
-         if (self.$element.attr('disabled')) {
-            self.$input.attr('disabled', 'disabled');
+         if (self.$element.prop('disabled')) {
+            self.$input.prop('disabled', true);
             return;
          }
 
@@ -491,7 +491,7 @@
 
       // Remove icon clicked
       self.$container.on('click', '[data-role=remove]', $.proxy(function(event) {
-        if (self.$element.attr('disabled')) {
+        if (self.$element.prop('disabled')) {
           return;
         }
         self.remove($(event.target).closest('.tag').data('item'));
@@ -503,7 +503,7 @@
             self.add(self.$element.val());
         } else {
           $('option', self.$element).each(function() {
-            self.add($(this).attr('value'), true);
+            self.add($(this).val(), true);
           });
         }
       }
@@ -567,7 +567,7 @@
           results.push(tagsinput);
 
           if (this.tagName === 'SELECT') {
-              $('option', $(this)).attr('selected', 'selected');
+              $('option', $(this)).prop('selected', true);
           }
 
           // Init tags from $(this).val()


### PR DESCRIPTION
As of jQuery 1.6, the .attr() method returns undefined for attributes that have not been set. To retrieve and change DOM properties such as the checked, selected, or disabled state of form elements, use the .prop() method.